### PR TITLE
Change MissingElementException path

### DIFF
--- a/src/View/PartialTrait.php
+++ b/src/View/PartialTrait.php
@@ -28,7 +28,7 @@ trait PartialTrait {
             list ($plugin, $name) = pluginSplit($name, true);
             $name = str_replace('/', DS, $name);
             $file = $plugin . $this->viewPath . DS . '_' . $name . $this->_ext;
-            throw new \Cake\View\Error\MissingElementException($file);
+            throw new \Cake\View\Exception\MissingElementException($file);
         }
     }
 


### PR DESCRIPTION
The error  occur when target ctp file missing,
because MissingElementException class path is changed.

```
Error: Class 'Cake\View\Error\MissingElementException' not found 
File /home/fusic/kyushu-u-article-search/vendor/kozo/partial/src/View/PartialTrait.php 
Line: 31
```
